### PR TITLE
Added new envs; accounted for new hostnames.

### DIFF
--- a/content-script/src/App.tsx
+++ b/content-script/src/App.tsx
@@ -5,11 +5,10 @@ import { getSyncData, setSyncData } from "@/lib/utils";
 
 function App() {
   const getEnv = () => {
-    const hostname = window.location.hostname.split(".")[0];
-    if (hostname.includes("dev")) {
-      return hostname.substring(4);
-    }
-    return hostname.split("-")[1] || "prod";
+    if (window.location.hostname.split(".")[1].includes("schoolinks")) {
+      return "prod";
+    } else 
+    return window.location.hostname.split(".")[1];;
   };
 
   const env = getEnv();

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,6 +4,10 @@ export const environments = [
     label: "dev-blue",
   },
   {
+    value: "qa-blue",
+    label: "qa-blue",
+  },
+  {
     value: "dev-green",
     label: "dev-green",
   },
@@ -12,8 +16,16 @@ export const environments = [
     label: "dev-purple",
   },
   {
+    value: "dev-lavender",
+    label: "dev-lavender",
+  },
+  {
     value: "dev-red",
     label: "dev-red",
+  },
+  {
+    value: "dev-crimson",
+    label: "dev-crimson",
   },
   {
     value: "qa",
@@ -30,5 +42,9 @@ export const environments = [
   {
     value: "prod",
     label: "prod",
+  },
+  {
+    value: "dataops",
+    label: "dataops",
   },
 ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -145,14 +145,22 @@ function App() {
 
   const getEnvColor = (e?: string) => {
     switch (e || env) {
+      case "dataops":
+        return "text-dataops";
       case "dev-blue":
         return "text-dev-blue";
+      case "qa-dev":
+        return "text-qa-blue"
       case "dev-green":
         return "text-dev-green";
       case "dev-purple":
         return "text-dev-purple";
+      case "dev-lavender":
+        return "text-dev-lavender";
       case "dev-red":
         return "text-dev-red";
+      case "dev-crimson":
+          return "text-dev-crimson";
       case "qa":
         return "text-qa";
       case "staging":

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,11 +10,15 @@ module.exports = {
   theme: {
     colors: {
       "dev-blue": "#2563eb",
+      "qa-blue": "#2563eb",
       "dev-green": "#16a34a",
       "dev-purple": "#673ab7",
+      "dev-lavender": "#673ab7",
       "dev-red": "#dc2626",
+      "dev-crimson": "#dc2626",
       qa: "#3f51b5",
       staging: "#a56800",
+      dataops: "#a56800",
       stable: "#598FA5",
       prod: "#9b1f1f",
     },


### PR DESCRIPTION
Hey Jon,
I tested this on all the env's I can access:

prod
stable
qa
dev-purple
dev-lavender
dev-blue
qa-blue
dev-green
dev-red
dev-crimson
dataops
... and it was working.  I tried with both students and K12s from the user table.
<img width="616" alt="image" src="https://github.com/jon-sl/schoolinks-user-tracker/assets/70173262/01273848-e4c4-4b97-9c2f-793b6584bb30">


I don't have access to:
e2e
staging (it's still updating the DB I take it)
dev-orange? (I guess that's what it's called?)
... so I can't verify those.